### PR TITLE
Fix :Get returned type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,10 +114,10 @@ interface Binder<T extends Binder.BinderClass = Binder.BinderClass> {
 	UnbindClient(instance: Instance): void;
 
 	/**
-	 * Returns a version of the class
+	 * Returns a version of the class, if it exists
 	 * @param instance
 	 */
-	Get(instance: Instance): T;
+	Get(instance: Instance): T | undefined;
 
 	/** Cleans up all bound classes, and disconnects all events */
 	Destroy(): void;


### PR DESCRIPTION
The current return type doesn't acknowledge the possibility that there might not be a class bound to an instance.